### PR TITLE
fix Firefox version in the 'lastError' compatibility table

### DIFF
--- a/webextensions/browser-compat-data.json
+++ b/webextensions/browser-compat-data.json
@@ -1323,7 +1323,7 @@
                     "support": "Unknown"
                 }, 
                 "Firefox": {
-                    "support": "45.0"
+                    "support": "47.0"
                 }
             }
         }, 


### PR DESCRIPTION
runtime.lastError was added as part of the following bugzilla issue:

- [Bug 1190680 - Support errors for open extension API via lastError](https://bugzilla.mozilla.org/show_bug.cgi?id=1190680)

This PR fixes the compat table to report 47 as the first Firefox version which supports it.